### PR TITLE
Spree API security backport

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -65,7 +65,7 @@ module Spree
       end
 
       def load_user
-        @current_api_user = (try_spree_current_user || Spree.user_class.find_by(spree_api_key: api_key.to_s))
+        @current_api_user = Spree.user_class.find_by(spree_api_key: api_key.to_s)
       end
 
       def authenticate_user

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -16,8 +16,6 @@ module Spree
       before_filter :authenticate_user
       before_filter :load_user_roles
 
-      after_filter  :set_jsonp_format
-
       rescue_from Exception, with: :error_during_processing
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from CanCan::AccessDenied, with: :unauthorized
@@ -26,13 +24,6 @@ module Spree
       helper Spree::Api::ApiHelpers
 
       ssl_allowed
-
-      def set_jsonp_format
-        if params[:callback] && request.get?
-          self.response_body = "#{params[:callback]}(#{response.body})"
-          headers["Content-Type"] = 'application/javascript'
-        end
-      end
 
       def map_nested_attributes_keys(klass, attributes)
         nested_keys = klass.nested_attributes_options.keys

--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -22,7 +22,7 @@ module Spree
         end
 
         def stub_authentication!
-          Spree::LegacyUser.stub(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
+          allow(Spree.user_class).to receive(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
         end
 
         # This method can be overriden (with a let block) inside a context

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -8,17 +8,9 @@ describe Spree::Api::BaseController do
     end
   end
 
-  context "signed in as a user using an authentication extension" do
-    before do
-      user = double(:email => "spree@example.com")
-      user.stub_chain :spree_roles, pluck: []
-      controller.stub :try_spree_current_user => user
-    end
-
-    it "can make a request" do
-      api_get :index
-      json_response.should == { "products" => [] }
-      response.status.should == 200
+  before do
+    @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
+      r.draw { get 'index', to: 'spree/api/base#index' }
     end
   end
 

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -10,8 +10,11 @@ module Spree
     let(:attributes) { [:id, :quantity, :price, :variant, :total, :display_amount, :single_display_amount] }
     let(:resource_scoping) { { :order_id => order.to_param } }
 
+    before do
+      stub_authentication!
+    end
+
     it "can learn how to create a new line item" do
-      controller.stub :try_spree_current_user => current_api_user
       api_get :new
       json_response["attributes"].should == ["quantity", "price", "variant_id"]
       required_attributes = json_response["required_attributes"]
@@ -37,8 +40,7 @@ module Spree
 
     context "as the order owner" do
       before do
-        controller.stub :try_spree_current_user => current_api_user
-        Order.any_instance.stub :user => current_api_user
+        allow_any_instance_of(Order).to receive_messages :user => current_api_user
       end
 
       it "can add a new line item to an existing order" do
@@ -126,7 +128,6 @@ module Spree
     context "as just another user" do
       before do
         user = create(:user)
-        controller.stub :try_spree_current_user => user
       end
 
       it "cannot add a new line item to the order" do

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -131,10 +131,10 @@ module Spree
 
       it "can view an order" do
         user = mock_model(Spree::LegacyUser)
-        user.stub_chain(:spree_roles, :pluck).and_return(["bar"])
-        user.stub(:has_spree_role?).with('bar').and_return(true)
-        user.stub(:has_spree_role?).with('admin').and_return(false)
-        controller.stub try_spree_current_user: user
+        allow(user).to receive_message_chain(:spree_roles, :pluck).and_return(["bar"])
+        allow(user).to receive(:has_spree_role?).with('bar').and_return(true)
+        allow(user).to receive(:has_spree_role?).with('admin').and_return(false)
+        allow(Spree.user_class).to receive_messages find_by: user
         api_get :show, :id => order.to_param
         response.status.should == 200
       end

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -145,21 +145,6 @@ module Spree
         end
       end
 
-      context "jsonp" do
-        it "retrieves a list of products of jsonp" do
-          api_get :index, {:callback => 'callback'}
-          response.body.should =~ /^callback\(.*\)$/
-          response.header['Content-Type'].should include('application/javascript')
-        end
-
-        # Regression test for #4332
-        it "does not escape quotes" do
-          api_get :index, {:callback => 'callback'}
-          response.body.should =~ /^callback\({"count":1,"total_count":1/
-          response.header['Content-Type'].should include('application/javascript')
-        end
-      end
-
       it "can search for products" do
         create(:product, :name => "The best product in the world")
         api_get :index, :q => { :name_cont => "best" }

--- a/api/spec/controllers/spree/api/users_controller_spec.rb
+++ b/api/spec/controllers/spree/api/users_controller_spec.rb
@@ -4,50 +4,48 @@ module Spree
   describe Api::UsersController do
     render_views
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user, spree_api_key: rand) }
     let(:stranger) { create(:user, :email => 'stranger@example.com') }
     let(:attributes) { [:id, :email, :created_at, :updated_at] }
 
-    before { stub_authentication! }
-
     context "as a normal user" do
-      before do
-        controller.stub :try_spree_current_user => user
-      end
-
       it "can get own details" do
-        api_get :show, :id => user.id
+        api_get :show, id: user.id, token: user.spree_api_key
 
         json_response['email'].should eq user.email
       end
 
       it "cannot get other users details" do
-        api_get :show, :id => stranger.id
+        api_get :show, id: stranger.id, token: user.spree_api_key
 
         assert_not_found!
       end
 
       it "can learn how to create a new user" do
-        api_get :new
-        json_response["attributes"].should == attributes.map(&:to_s)
+        api_get :new, token: user.spree_api_key
+        expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
       end
 
       it "can create a new user" do
-        api_post :create, :user => { :email => 'new@example.com', :password => 'spree123', :password_confirmation => 'spree123' }
-        json_response['email'].should eq 'new@example.com'
+        user_params = {
+          :email => 'new@example.com', :password => 'spree123', :password_confirmation => 'spree123'
+        }
+
+        api_post :create, :user => user_params, token: user.spree_api_key
+        expect(json_response['email']).to eq 'new@example.com'
       end
 
       # there's no validations on LegacyUser?
       xit "cannot create a new user with invalid attributes" do
-        api_post :create, :user => {}
-        response.status.should == 422
-        json_response["error"].should == "Invalid resource. Please fix errors and try again."
+        api_post :create, :user => {}, token: user.spree_api_key
+        expect(response.status).to eq(422)
+        expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
         errors = json_response["errors"]
       end
 
       it "can update own details" do
         country = create(:country)
-        api_put :update, id: user.id, user: {
+        api_put :update, id: user.id, token: user.spree_api_key, user: {
           email: "mine@example.com",
           bill_address_attributes: {
             first_name: 'First',
@@ -76,23 +74,23 @@ module Spree
       end
 
       it "cannot update other users details" do
-        api_put :update, :id => stranger.id, :user => { :email => "mine@example.com" }
+        api_put :update, id: stranger.id, token: user.spree_api_key, user: { :email => "mine@example.com" }
         assert_not_found!
       end
 
       it "can delete itself" do
-        api_delete :destroy, :id => user.id
-        response.status.should == 204
+        api_delete :destroy, id: user.id, token: user.spree_api_key
+        expect(response.status).to eq(204)
       end
 
       it "cannot delete other user" do
-        api_delete :destroy, :id => stranger.id
+        api_delete :destroy, id: stranger.id, token: user.spree_api_key
         assert_not_found!
       end
 
       it "should only get own details on index" do
         2.times { create(:user) }
-        api_get :index
+        api_get :index, token: user.spree_api_key
 
         Spree.user_class.count.should eq 3
         json_response['count'].should eq 1
@@ -101,6 +99,8 @@ module Spree
     end
 
     context "as an admin" do
+      before { stub_authentication! }
+
       sign_in_as_admin!
 
       it "gets all users" do

--- a/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
@@ -6,6 +6,7 @@ $(@).ready( ->
       url: Spree.url(Spree.routes.apply_coupon_code(order_number))
       data:
         coupon_code: $("#coupon_code").val()
+        token: Spree.api_key
       success: ->
         window.location.reload();
       error: (msg) ->

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -19,7 +19,10 @@ $(document).ready(function() {
         url: Spree.routes.user_search,
         datatype: 'json',
         data: function(term, page) {
-          return { q: term }
+          return {
+            q: term,
+            token: Spree.api_key
+          }
         },
         results: function(data, page) {
           return { results: data }

--- a/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
@@ -46,6 +46,7 @@ adjustLineItem = (line_item_id, quantity) ->
     data:
       line_item:
         quantity: quantity
+      token: Spree.api_key
   ).done (msg) ->
     advanceOrder()
 
@@ -54,6 +55,8 @@ deleteLineItem = (line_item_id) ->
   $.ajax(
     type: "DELETE"
     url: Spree.url(url)
+    data:
+      token: Spree.api_key
   ).done (msg) ->
     $('#line-item-' + line_item_id).remove()
     if $('.line-items tr.line-item').length == 0

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
@@ -7,7 +7,8 @@ $(document).ready(function () {
       multiple: true,
       initSelection: function (element, callback) {
         var url = Spree.url(Spree.routes.option_type_search, {
-          ids: element.val()
+          ids: element.val(),
+          token: Spree.api_key
         });
         return $.getJSON(url, null, function (data) {
           return callback(data);

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
@@ -21,7 +21,8 @@ $(document).ready(function () {
           return {
             q: {
               name_cont: term
-            }
+            },
+            token: Spree.api_key
           };
         },
         results: function (data) {

--- a/backend/app/assets/javascripts/spree/backend/orders/edit_form.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit_form.js
@@ -9,7 +9,8 @@ $(document).ready(function () {
 
       $.post('/admin/orders/' + $('input#order_number').val() + '/line_items/' + $(id).val(), {
           _method: 'put',
-          'line_item[quantity]': $(this).val()
+          'line_item[quantity]': $(this).val(),
+          token: Spree.api_key
         },
 
         function (resp) {

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -3,7 +3,7 @@ jQuery ($) ->
   order_id = $('#payments').data('order-id')
   class Payment
     constructor: (id) ->
-      @url  = Spree.url("#{Spree.routes.payments_api(order_id)}/#{id}.json")
+      @url  = Spree.url("#{Spree.routes.payments_api(order_id)}/#{id}.json" + '?token=' + Spree.api_key)
       @json = $.getJSON @url.toString(), (data) =>
         @data = data
 

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -20,7 +20,8 @@ $.fn.productAutocomplete = function () {
             name_cont: term,
             sku_cont: term
           },
-          m: 'OR'
+          m: 'OR',
+          token: Spree.api_key
         };
       },
       results: function (data, page) {

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -6,7 +6,8 @@ $.fn.productAutocomplete = function () {
     multiple: true,
     initSelection: function (element, callback) {
       $.get(Spree.routes.product_search, {
-        ids: element.val().split(',')
+        ids: element.val().split(','),
+        token: Spree.api_key
       }, function (data) {
         callback(data.products);
       });

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -66,7 +66,10 @@ $(document).ready(function () {
     var url = Spree.url(Spree.routes.shipments_api + '/' + shipment_number + '/ship.json');
     $.ajax({
       type: 'PUT',
-      url: url
+      url: url,
+      data: {
+        token: Spree.api_key
+      }
     }).done(function () {
       window.location.reload();
     }).error(function (msg) {
@@ -95,7 +98,8 @@ $(document).ready(function () {
         shipment: {
           selected_shipping_rate_id: selected_shipping_rate_id,
           unlock: unlock
-        }
+        },
+        token: Spree.api_key
       }
     }).done(function () {
       window.location.reload();
@@ -131,7 +135,8 @@ $(document).ready(function () {
       data: {
         shipment: {
           tracking: tracking
-        }
+        },
+        token: Spree.api_key
       }
     }).done(function (data) {
       link.parents('tbody').find('tr.edit-tracking').toggle();
@@ -163,7 +168,11 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
       $.ajax({
         type: "PUT",
         url: Spree.url(url),
-        data: { variant_id: variant_id, quantity: new_quantity }
+        data: {
+          variant_id: variant_id,
+          quantity: new_quantity,
+          token: Spree.api_key
+        }
       }).done(function( msg ) {
         window.location.reload();
       });
@@ -207,7 +216,8 @@ startItemSplit = function(event){
     data: {
       q: {
         "id_eq": variant_id
-      }
+      },
+      token: Spree.api_key
     }
   }).success(function( data ) {
     variant = data['variants'][0];
@@ -260,7 +270,7 @@ completeItemSplit = function(event) {
         type: "POST",
         async: false,
         url: Spree.url(Spree.routes.shipments_api + "?shipment[order_id]=" + order_number),
-        data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
+        data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id, token: Spree.api_key }
       }).done(function(msg) {
         advanceOrder();
       });
@@ -269,7 +279,7 @@ completeItemSplit = function(event) {
         type: "PUT",
         async: false,
         url: Spree.url(Spree.routes.shipments_api + "/" + target_shipment_number + "/add.json"),
-        data: { variant_id: variant_id, quantity: quantity }
+        data: { variant_id: variant_id, quantity: quantity, token: Spree.api_key }
       }).done(function(msg) {
         advanceOrder();
       });
@@ -314,7 +324,12 @@ addVariantFromStockLocation = function(event) {
     $.ajax({
       type: "POST",
       url: Spree.url(Spree.routes.shipments_api + "?shipment[order_id]=" + order_number),
-      data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
+      data: {
+        variant_id: variant_id,
+        quantity: quantity,
+        stock_location_id: stock_location_id,
+        token: Spree.api_key
+      }
     }).done(function( msg ) {
       window.location.reload();
     }).error(function( msg ) {

--- a/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
@@ -9,6 +9,7 @@ jQuery ->
           variant_product_name_cont: term
         per_page: 50
         page: page
+        token: Spree.api_key
       results: (data, page) ->
         more = (page * 50) < data.count
         return { results: data.stock_items, more: more }

--- a/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
@@ -30,7 +30,7 @@ $ ->
 
       $('#transfer_receive_stock').change (event) => @receive_stock_change(event)
 
-      $.getJSON Spree.url(Spree.routes.stock_locations_api), (data) =>
+      $.getJSON Spree.url(Spree.routes.stock_locations_api) + '?token=' + Spree.api_key, (data) =>
         @locations = (location for location in data.stock_locations)
         @force_receive_stock() if @locations.length < 2
 
@@ -107,6 +107,7 @@ $ ->
             query_object = {}
             query_object[query] = term
             q: query_object
+            token: Spree.api_key
 
           results: (data, page) ->
             result = data["variants"] || data["stock_items"]

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -7,7 +7,8 @@ $(document).ready(function () {
       multiple: true,
       initSelection: function (element, callback) {
         var url = Spree.url(Spree.routes.taxons_search, {
-          ids: element.val()
+          ids: element.val(),
+          token: Spree.api_key
         });
         return $.getJSON(url, null, function (data) {
           return callback(data['taxons']);

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -23,7 +23,8 @@ $(document).ready(function () {
             without_children: true,
             q: {
               name_cont: term
-            }
+            },
+            token: Spree.api_key
           };
         },
         results: function (data, page) {

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -14,7 +14,12 @@ handle_move = (e, data) ->
     type: "POST",
     dataType: "json",
     url: url.toString(),
-    data: ({_method: "put", "taxon[parent_id]": new_parent.prop("id"), "taxon[child_index]": position }),
+    data: {
+      _method: "put",
+      "taxon[parent_id]": new_parent.prop("id"),
+      "taxon[child_index]": position,
+      token: Spree.api_key
+    },
     error: handle_ajax_error
 
   true
@@ -30,7 +35,12 @@ handle_create = (e, data) ->
     type: "POST",
     dataType: "json",
     url: base_url.toString(),
-    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.prop("id"), "taxon[child_index]": position }),
+    data: {
+      "taxon[name]": name,
+      "taxon[parent_id]": new_parent.prop("id"),
+      "taxon[child_index]": position,
+      token: Spree.api_key
+    },
     error: handle_ajax_error,
     success: (data,result) ->
       node.prop('id', data.id)
@@ -47,7 +57,11 @@ handle_rename = (e, data) ->
     type: "POST",
     dataType: "json",
     url: url.toString(),
-    data: {_method: "put", "taxon[name]": name },
+    data: {
+      _method: "put",
+      "taxon[name]": name,
+      token: Spree.api_key
+    },
     error: handle_ajax_error
 
 handle_delete = (e, data) ->
@@ -61,7 +75,10 @@ handle_delete = (e, data) ->
         type: "POST",
         dataType: "json",
         url: delete_url.toString(),
-        data: {_method: "delete"},
+        data: {
+          _method: "delete",
+          token: Spree.api_key
+        },
         error: handle_ajax_error
     else
       $.jstree.rollback(last_rollback)
@@ -75,6 +92,8 @@ root.setup_taxonomy_tree = (taxonomy_id) ->
 
     $.ajax
       url: Spree.url(base_url.path().replace("/taxons", "/jstree")).toString(),
+      data:
+        token: Spree.api_key
       success: (taxonomy) ->
         last_rollback = null
 
@@ -83,7 +102,7 @@ root.setup_taxonomy_tree = (taxonomy_id) ->
             data: taxonomy,
             ajax:
               url: (e) ->
-                Spree.url(base_url.path() + '/' + e.prop('id') + '/jstree').toString()
+                Spree.url(base_url.path() + '/' + e.prop('id') + '/jstree' + '?token=' + Spree.api_key).toString()
           themes:
             theme: "apple",
             url: Spree.url(Spree.routes.jstree_theme_path)

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -6,6 +6,7 @@ $(document).ready ->
       url: Spree.routes.classifications_api,
       method: 'PUT',
       data:
+        token: Spree.api_key,
         product_id: ui.item.data('product-id'),
         taxon_id: $('#taxon_id').val(),
         position: ui.item.index()

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -20,6 +20,7 @@ $(document).ready ->
         data: (term, page) ->
           per_page: 50,
           page: page,
+          token: Spree.api_key,
           q:
             name_cont: term
         results: (data, page) ->
@@ -36,7 +37,8 @@ $(document).ready ->
     $.ajax
       url: Spree.routes.taxon_products_api,
       data:
-        id: e.val
+        id: e.val,
+        token: Spree.api_key
       success: (data) ->
         el.empty();
         if data.products.length == 0
@@ -48,4 +50,3 @@ $(document).ready ->
               product.image = product.master.images[0].small_url
             el.append(productTemplate({ product: product }))
           $('#sorting_explanation').show()
-

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -16,7 +16,8 @@ $.fn.userAutocomplete = function () {
       datatype: 'json',
       data: function (term) {
         return {
-          q: term
+          q: term,
+          token: Spree.api_key
         };
       },
       results: function (data) {

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
@@ -22,6 +22,7 @@ $.fn.variantAutocomplete = ->
       data: (term, page) ->
         q:
           product_name_or_sku_cont: term
+        token: Spree.api_key
 
       results: (data, page) ->
         window.variants = data["variants"]

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -23,6 +23,7 @@
 <%= javascript_tag do -%>
   jQuery.alerts.dialogClass = 'spree';
   <%== "var AUTH_TOKEN = #{form_authenticity_token.inspect};" %>
-<% end -%>
+  <%== "Spree.api_key = '#{try_spree_current_user.spree_api_key}';" if try_spree_current_user %>
+<% end %>
 
 <%= yield :head %>

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Cancelling + Resuming" do
   stub_authorization!
 
-  let(:order) do 
+  let(:order) do
     order = create(:order)
     order.update_columns({
       :state => 'complete',

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -200,7 +200,7 @@ describe "Order Details", js: true do
           end
         end
       end
-      
+
       context "with special_instructions present" do
         let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
         it "will show the special_instructions" do
@@ -233,7 +233,7 @@ describe "Order Details", js: true do
   end
 
   context 'with only read permissions' do
-    before do 
+    before do
       Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
     end
 
@@ -271,7 +271,9 @@ describe "Order Details", js: true do
     end
 
     before do
-      Spree::Api::BaseController.any_instance.stub :try_spree_current_user => Spree.user_class.new
+      allow(Spree.user_class).to receive(:find_by).
+                                   with(hash_including(:spree_api_key)).
+                                   and_return(Spree.user_class.new)
     end
 
     it 'should not display order tabs or edit buttons without ability' do

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -37,7 +37,9 @@ module Spree
           end
 
           before do
-            allow_any_instance_of(Api::BaseController).to receive(:try_spree_current_user).and_return(Spree.user_class.new)
+            allow(Spree.user_class).to receive(:find_by).
+                                         with(hash_including(:spree_api_key)).
+                                         and_return(Spree.user_class.new)
           end
         end
 
@@ -56,6 +58,6 @@ module Spree
 end
 
 RSpec.configure do |config|
-  config.extend Spree::TestingSupport::AuthorizationHelpers::Controller, :type => :controller
-  config.extend Spree::TestingSupport::AuthorizationHelpers::Request, :type => :feature
+  config.extend Spree::TestingSupport::AuthorizationHelpers::Controller, type: :controller
+  config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :feature
 end


### PR DESCRIPTION
Fixes the Spree API JSONP security exposure by requiring API tokens for users making Spree API requests (details: https://github.com/redbadger/fm-ecom/issues/1951)

Commits cherry picked from https://github.com/spree/spree/tree/2-3-stable :
- https://github.com/spree/spree/commit/5409de614da27431321e57f2cfcf940a1b15e3f0
- https://github.com/spree/spree/commit/653541197addbc09af6a0f75aff2c5d283b0bab6
- https://github.com/spree/spree/commit/ae46145deb15df864819a1eb356eaa098bc73485
- https://github.com/spree/spree/commit/aa3cf91a22e5b02a121bd569dc8789030be8d3d9
- https://github.com/spree/spree/commit/0d9b4da23a3e9800e924dcecc8da3db5268b20da
- https://github.com/spree/spree/commit/ff5e8ce3b24f75bf982dd11048ae3a5868139cf5
- https://github.com/spree/spree/commit/bc4ac73fe75aa09e879d20b0cf7c1b2c7f2fba94

**NOTE:** This will require admin users to have API keys generated for them in the admin controls of spree for full admin functionality.
