### PR TITLE
Remove preferences configuration from admin

### DIFF
--- a/api/app/views/spree/api/config/money.v1.rabl
+++ b/api/app/views/spree/api/config/money.v1.rabl
@@ -1,6 +1,2 @@
 object false
 node(:symbol) { ::Money.new(1, Spree::Config[:currency]).symbol }
-node(:symbol_position) { Spree::Config[:currency_symbol_position] }
-node(:no_cents) { Spree::Config[:hide_cents] }
-node(:decimal_mark) { Spree::Config[:currency_decimal_mark] }
-node(:thousands_separator) { Spree::Config[:currency_thousands_separator] }

--- a/api/spec/controllers/spree/api/config_controller_spec.rb
+++ b/api/spec/controllers/spree/api/config_controller_spec.rb
@@ -10,12 +10,8 @@ module Spree
 
     it "returns Spree::Money settings" do
       api_get :money
-      response.should be_success
-      json_response["symbol"].should == "$"
-      json_response["symbol_position"].should == "before"
-      json_response["no_cents"].should == false
-      json_response["decimal_mark"].should == "."
-      json_response["thousands_separator"].should == ","
+      expect(response).to be_success
+      expect(json_response["symbol"]).to eq("$")
     end
 
     it "returns some configuration settings" do

--- a/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
@@ -49,8 +49,10 @@ $ ->
       @source.trigger('change')
       if @is_source_location_hidden() and not hide
         $('#transfer_source_location_id_field').css('visibility', 'visible')
+        $('#transfer_source_location_id_field').show()
       else
         $('#transfer_source_location_id_field').css('visibility', 'hidden')
+        $('#transfer_source_location_id_field').hide()
 
     receive_stock_change: (event) ->
       @toggle_source_location event.target.checked

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -4,10 +4,7 @@ module Spree
       before_filter :set_store
 
       def edit
-        @preferences_security = [:allow_ssl_in_production,
-                        :allow_ssl_in_staging, :allow_ssl_in_development_and_test,
-                        :check_for_spree_alerts]
-        @preferences_currency = [:display_currency, :hide_cents]
+        @preferences_security = [:check_for_spree_alerts]
       end
 
       def update

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -58,31 +58,14 @@
         <div class="omega six columns">
           <fieldset class="currency no-border-bottom">
             <legend align="center"><%= Spree.t(:currency_settings)%></legend>
-            <% @preferences_currency.each do |key|
-                type = Spree::Config.preference_type(key) %>
-                <div class="field">
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
-                </div>
-            <% end %>
             <div class="field">
               <%= label_tag :currency, Spree.t(:choose_currency) %><br>
               <%= select_tag :currency, currency_options, :class => 'fullwidth' %>
             </div>
-            <div class="field">
-              <%= label_tag Spree.t(:currency_symbol_position) %><br>
-              <div class="choices">
-                <ul>
-                  <li>
-                    <%= radio_button_tag :currency_symbol_position, "before", Spree::Config[:currency_symbol_position] == "before" %>
-                    <%= label_tag :currency_symbol_position_before, Spree::Money.new(10, :symbol_position => "before") %>
-                  </li>
-                  <li class="white-space-nowrap">
-                    <%= radio_button_tag :currency_symbol_position, "after", Spree::Config[:currency_symbol_position] == "after" %>
-                    <%= label_tag :currency_symbol_position_after, Spree::Money.new(10, :symbol_position => "after") %>
-                  </li>
-                </ul>
+            <div class="panel-body">
+              <div class="form-group">
+                <%= label_tag :currency, Spree.t(:choose_currency) %>
+                <%= select_tag :currency, currency_options %>
               </div>
             </div>
             <div class="field">

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -68,14 +68,6 @@
                 <%= select_tag :currency, currency_options %>
               </div>
             </div>
-            <div class="field">
-              <%= label_tag :currency_decimal_mark, Spree.t(:currency_decimal_mark) %><br>
-              <%= text_field_tag :currency_decimal_mark, Spree::Config[:currency_decimal_mark], :size => 3 %>
-            </div>
-            <div class="field">
-              <%= label_tag :currency_thousands_separator, Spree.t(:currency_thousands_separator) %><br>
-              <%= text_field_tag :currency_thousands_separator, Spree::Config[:currency_thousands_separator], :size => 3 %>
-            </div>
           </fieldset>
         </div>
       </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -63,8 +63,8 @@ describe "Products" do
           # Regression test for #2737
           context "uses руб as the currency symbol" do
             it "on the products listing page" do
-              click_link "Products"
-              within_row(1) { page.should have_content("руб19.99") }
+              visit spree.admin_products_path
+              within_row(1) { expect(page).to have_content("19.99 ₽") }
             end
           end
         end
@@ -252,7 +252,7 @@ describe "Products" do
         page.should have_content("successfully updated!")
       end
     end
-    
+
 
     context "cloning a product", :js => true do
       it "should allow an admin to clone a product" do
@@ -343,8 +343,8 @@ describe "Products" do
   end
 
   context 'with only product permissions' do
-  
-    before do 
+
+    before do
       Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
     end
 
@@ -365,7 +365,7 @@ describe "Products" do
       page.should have_css('a.edit')
       page.should_not have_css('a.delete-resource')
     end
-  
+
     it "should only display accessible links on edit" do
       visit spree.admin_product_path(product)
 

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -42,7 +42,7 @@ describe "Variants" do
         context "uses руб as the currency symbol" do
           it "on the products listing page" do
             visit spree.admin_product_variants_path(product)
-            within_row(1) { page.should have_content("руб19.99") }
+            within_row(1) { expect(page).to have_content("19.99 ₽") }
           end
         end
       end

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -1,0 +1,184 @@
+#!/usr/bin/env ruby
+
+require 'pathname'
+
+class Project
+  attr_reader :name
+
+  NODE_TOTAL = Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1))
+  NODE_INDEX = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
+
+  ROOT          = Pathname.pwd.freeze
+  VENDOR_BUNDLE = ROOT.join('vendor', 'bundle').freeze
+
+  BUNDLER_JOBS    = 4
+  BUNDLER_RETRIES = 3
+
+  DEFAULT_MODE = 'test'.freeze
+
+  def initialize(name)
+    @name = name
+  end
+
+  ALL = %w[api backend core frontend sample].map(&method(:new)).freeze
+
+  # Install subproject
+  #
+  # @raise [RuntimeError]
+  #   in case of failure
+  #
+  # @return [self]
+  #   otherwise
+  def install
+    chdir do
+      bundle_check or bundle_install or fail 'Cannot finish gem installation'
+    end
+    self
+  end
+
+  # Test subproject for passing its tests
+  #
+  # @return [Boolean]
+  #   the success of the build
+  def pass?
+    chdir do
+      setup_test_app
+      run_tests
+    end
+  end
+
+private
+
+  # Check if current bundle is already usable
+  #
+  # @return [Boolean]
+  def bundle_check
+    system(%W[bundle check --path=#{VENDOR_BUNDLE}])
+  end
+
+  # Install the current bundle
+  #
+  # @return [Boolean]
+  #   the success of the installation
+  def bundle_install
+    system(%W[
+      bundle
+      install
+      --path=#{VENDOR_BUNDLE}
+      --jobs=#{BUNDLER_JOBS}
+      --retry=#{BUNDLER_RETRIES}
+    ])
+  end
+
+  # Setup the test app
+  #
+  # @return [undefined]
+  def setup_test_app
+    system(%w[bundle exec rake test_app]) or fail 'Failed to setup the test app'
+  end
+
+  # Run tests for subproject
+  #
+  # @return [Boolean]
+  #   the success of the tests
+  def run_tests
+    system(%w[bundle exec rspec spec])
+  end
+
+  # Execute system command via execve
+  #
+  # No shell interpolation gets done this way. No escapes needed.
+  #
+  # @return [Boolean]
+  #   the success of the system command
+  def system(arguments)
+    Kernel.system(*arguments)
+  end
+
+  # Change to subproject directory and execute block
+  #
+  # @return [undefined]
+  def chdir(&block)
+    Dir.chdir(ROOT.join(name), &block)
+  end
+
+  # Install subprojects
+  #
+  # @return [self]
+  def self.install
+    current_projects.each do |project|
+      log("Installing project: #{project.name}")
+      project.install
+    end
+    self
+  end
+  private_class_method :install
+
+  # Execute tests on subprojects
+  #
+  # @return [Boolean]
+  #   the success of ALL subprojects
+  def self.test
+    projects = current_projects
+    suffix   = "#{projects.length} projects(s) on node #{NODE_INDEX.succ} / #{NODE_TOTAL}"
+
+    log("Running #{suffix}")
+    projects.each do |project|
+      log("- #{project.name}")
+    end
+
+    builds = projects.map do |project|
+      log("Building: #{project.name}")
+      project.pass?
+    end
+    log("Finished running #{suffix}")
+
+    projects.zip(builds).each do |project, build|
+      log("- #{project.name} #{build ? 'SUCCESS' : 'FAILURE'}")
+    end
+
+    builds.all?
+  end
+  private_class_method :test
+
+  # Return the projects active on current node
+  #
+  # @return [Array<Project>]
+  def self.current_projects
+    NODE_INDEX.step(ALL.length - 1, NODE_TOTAL).map(&ALL.method(:fetch))
+  end
+  private_class_method :current_projects
+
+  # Log a progress message to stderr
+  #
+  # @param [String] message
+  #
+  # @return [undefined]
+  def self.log(message)
+    $stderr.puts(message)
+  end
+  private_class_method :log
+
+  # Process CLI arguments
+  #
+  # @param [Array<String>] arguments
+  #
+  # @return [Boolean]
+  #   the success of the CLI run
+  def self.run_cli(arguments)
+    fail ArgumentError if arguments.length > 1
+    mode = arguments.fetch(0, DEFAULT_MODE)
+
+    case mode
+    when 'install'
+      install
+      true
+    when 'test'
+      test
+    else
+      fail "Unknown mode: #{mode.inspect}"
+    end
+  end
+end # Project
+
+exit Project.run_cli(ARGV)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+---
+machine:
+  environment:
+    DB: postgres
+  services:
+    - postgresql
+  ruby:
+    version: 2.1.3
+dependencies:
+  override:
+    - ./build-ci.rb install
+test:
+  override:
+    - './build-ci.rb test':
+       parallel: true

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -39,14 +39,10 @@ module Spree
     preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
     preference :company, :boolean, default: false # Request company field for billing and shipping addr
     preference :currency, :string, default: "USD"
-    preference :currency_decimal_mark, :string, default: "."
-    preference :currency_symbol_position, :string, default: "before"
-    preference :currency_sign_before_symbol, :boolean, default: true
-    preference :currency_thousands_separator, :string, default: ","
-    preference :display_currency, :boolean, default: false
     preference :default_country_id, :integer
     preference :dismissed_spree_alerts, :string, default: ''
-    preference :hide_cents, :boolean, default: false
+    preference :expedited_exchanges, :boolean, default: false # NOTE this requires payment profiles to be supported on your gateway of choice as well as a delayed job handler to be configured with activejob. kicks off an exchange shipment upon return authorization save. charge customer if they do not return items within timely manner.
+    preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
     preference :last_check_for_spree_alerts, :string, default: nil
     preference :layout, :string, default: 'spree/layouts/spree_application'
     preference :logo, :string, default: 'logo/spree_50.png'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -520,10 +520,7 @@ en:
     credit_cards: Credit Cards
     credit_owed: Credit Owed
     currency: Currency
-    currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
-    currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator: Currency thousands separator
     current: Current
     current_promotion_usage: ! 'Current Usage: %{count}'
     customer: Customer
@@ -561,7 +558,7 @@ en:
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
-    display_currency: Display currency
+    doesnt_track_inventory: It doesnt track inventory
     edit: Edit
     editing_option_type: Editing Option Type
     editing_payment_method: Editing Payment Method
@@ -643,7 +640,6 @@ en:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents: Hide cents
     home: Home
     i18n:
       available_locales: Available Locales

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -4,22 +4,22 @@ require 'money'
 
 module Spree
   class Money
+    class <<self
+      attr_accessor :default_formatting_rules
+    end
+    self.default_formatting_rules = {
+      # Ruby money currently has this as false, which is wrong for the vast
+      # majority of locales.
+      sign_before_symbol: true
+    }
+
     attr_reader :money
 
     delegate :cents, :to => :money
 
     def initialize(amount, options={})
       @money = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
-      @options = {}
-      @options[:with_currency] = Spree::Config[:display_currency]
-      @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym
-      @options[:no_cents] = Spree::Config[:hide_cents]
-      @options[:decimal_mark] = Spree::Config[:currency_decimal_mark]
-      @options[:thousands_separator] = Spree::Config[:currency_thousands_separator]
-      @options[:sign_before_symbol] = Spree::Config[:currency_sign_before_symbol]
-      @options.merge!(options)
-      # Must be a symbol because the Money gem doesn't do the conversion
-      @options[:symbol_position] = @options[:symbol_position].to_sym
+      @options = Spree::Money.default_formatting_rules.merge(options)
     end
 
     def to_s

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -60,7 +60,7 @@ describe Spree::Money do
     end
 
     it "passed in option string" do
-      money = Spree::Money.new(10, :symbol_position => "after", :html => false)
+      money = Spree::Money.new(10, :symbol_position => :after :html => false)
       money.to_s.should == "10.00 $"
     end
 

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -60,7 +60,7 @@ describe Spree::Money do
     end
 
     it "passed in option string" do
-      money = Spree::Money.new(10, :symbol_position => :after :html => false)
+      money = Spree::Money.new(10, :symbol_position => :after, :html => false)
       money.to_s.should == "10.00 $"
     end
 

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -5,8 +5,6 @@ describe Spree::Money do
   before do
     configure_spree_preferences do |config|
       config.currency = "USD"
-      config.currency_symbol_position = :before
-      config.display_currency = false
     end
   end
 
@@ -25,23 +23,15 @@ describe Spree::Money do
       money = Spree::Money.new(10, :with_currency => true, :html => false)
       money.to_s.should == "$10.00 USD"
     end
-
-    it "config option" do
-      Spree::Config[:display_currency] = true
-      money = Spree::Money.new(10, :html => false)
-      money.to_s.should == "$10.00 USD"
-    end
   end
 
   context "hide cents" do
     it "hides cents suffix" do
-      Spree::Config[:hide_cents] = true
-      money = Spree::Money.new(10)
-      money.to_s.should == "$10"
+      money = Spree::Money.new(10, no_cents: true)
+      expect(money.to_s).to eq("$10")
     end
 
     it "shows cents suffix" do
-      Spree::Config[:hide_cents] = false
       money = Spree::Money.new(10)
       money.to_s.should == "$10.00"
     end
@@ -75,9 +65,8 @@ describe Spree::Money do
     end
 
     it "config option" do
-      Spree::Config[:currency_symbol_position] = :after
-      money = Spree::Money.new(10, :html => false)
-      money.to_s.should == "10.00 $"
+      money = Spree::Money.new(10, symbol_position: :after, html: false)
+      expect(money.to_s).to eq("10.00 $")
     end
   end
 
@@ -91,20 +80,12 @@ describe Spree::Money do
       money = Spree::Money.new(-10, :sign_before_symbol => false)
       money.to_s.should == "$-10.00"
     end
-
-    it "config option" do
-      Spree::Config[:currency_sign_before_symbol] = false
-      money = Spree::Money.new(-10)
-      money.to_s.should == "$-10.00"
-    end
   end
 
   context "JPY" do
     before do
       configure_spree_preferences do |config|
         config.currency = "JPY"
-        config.currency_symbol_position = :before
-        config.display_currency = false
       end
     end
 
@@ -118,40 +99,23 @@ describe Spree::Money do
     before do
       configure_spree_preferences do |config|
         config.currency = "EUR"
-        config.currency_symbol_position = :after
-        config.display_currency = false
       end
     end
 
     # Regression test for #2634
     it "formats as plain by default" do
-      money = Spree::Money.new(10)
-      money.to_s.should == "10.00 €"
-    end
-
-    # Regression test for #2632
-    it "acknowledges decimal mark option" do
-      Spree::Config[:currency_decimal_mark] = ","
-      money = Spree::Money.new(10)
-      money.to_s.should == "10,00 €"
-    end
-
-    # Regression test for #2632
-    it "acknowledges thousands separator option" do
-      Spree::Config[:currency_thousands_separator] = "."
-      money = Spree::Money.new(1000)
-      money.to_s.should == "1.000.00 €"
+      money = Spree::Money.new(10, symbol_position: :after)
+      expect(money.to_s).to eq("10.00 €")
     end
 
     it "formats as HTML if asked (nicely) to" do
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, symbol_position: :after)
       # The HTML'ified version of "10.00 €"
       money.to_html.should == "10.00&nbsp;&#x20AC;"
     end
 
     it "formats as HTML with currency" do
-      Spree::Config[:display_currency] = true
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, symbol_position: :after, with_currency: true)
       # The HTML'ified version of "10.00 €"
       money.to_html.should == "10.00&nbsp;&#x20AC; <span class=\"currency\">EUR</span>"
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -52,20 +52,8 @@ describe Spree::Adjustment do
   context "#display_amount" do
     before { adjustment.amount = 10.55 }
 
-    context "with display_currency set to true" do
-      before { Spree::Config[:display_currency] = true }
-
-      it "shows the currency" do
-        expect(adjustment.display_amount.to_s).to eq "$10.55 USD"
-      end
-    end
-
-    context "with display_currency set to false" do
-      before { Spree::Config[:display_currency] = false }
-
-      it "does not include the currency" do
-        expect(adjustment.display_amount.to_s).to eq "$10.55"
-      end
+    it "shows the amount" do
+      expect(adjustment.display_amount.to_s).to eq "$10.55"
     end
 
     context "with currency set to JPY" do

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -4,7 +4,7 @@ describe Spree::CreditCard do
   let(:valid_credit_card_attributes) do
     { :number => '4111111111111111',
       :verification_value => '123',
-      :expiry => "12 / 14",
+      :expiry => "12 / 20",
       :name => "Spree Commerce" }
   end
 
@@ -113,7 +113,7 @@ describe Spree::CreditCard do
       # (Time.now).
       # However it has expired in rails's configured time zone (Time.current),
       # which is the value we should be respecting.
-      time = Time.new(2014, 04, 30, 23, 0, 0, "-07:00")
+      time = Time.new(2020, 04, 30, 23, 0, 0, "-07:00")
       Timecop.freeze(time) do
         credit_card.month = 1.month.ago.month
         credit_card.year = 1.month.ago.year
@@ -222,39 +222,39 @@ describe Spree::CreditCard do
   # Regression test for #3847 & #3896
   context "#expiry=" do
     it "can set with a 2-digit month and year" do
-      credit_card.expiry = '04 / 14'
+      credit_card.expiry = '04 / 20'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "can set with a 2-digit month and 4-digit year" do
-      credit_card.expiry = '04 / 2014'
+      credit_card.expiry = '04 / 2020'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace" do
-      credit_card.expiry = '04/14'
+      credit_card.expiry = '04/20'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace" do
-      credit_card.expiry = '04/2014'
+      credit_card.expiry = '04/2020'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace and slash" do
-      credit_card.expiry = '042014'
+      credit_card.expiry = '042020'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "can set with a 2-digit month and 2-digit year without whitespace and slash" do
-      credit_card.expiry = '0414'
+      credit_card.expiry = '0420'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2020)
     end
 
     it "does not blow up when passed an empty string" do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Payment do
     Spree::CreditCard.create!(
       number: "4111111111111111",
       month: "12",
-      year: "2014",
+      year: "2020",
       verification_value: "123",
       name: "Name",
       imported: false

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -145,20 +145,8 @@ describe Spree::Product do
     context "#display_price" do
       before { product.price = 10.55 }
 
-      context "with display_currency set to true" do
-        before { Spree::Config[:display_currency] = true }
-
-        it "shows the currency" do
-          product.display_price.to_s.should == "$10.55 USD"
-        end
-      end
-
-      context "with display_currency set to false" do
-        before { Spree::Config[:display_currency] = false }
-
-        it "does not include the currency" do
-          product.display_price.to_s.should == "$10.55"
-        end
+      it "shows the amount" do
+        expect(product.display_price.to_s).to eq("$10.55")
       end
 
       context "with currency set to JPY" do
@@ -188,10 +176,10 @@ describe Spree::Product do
         product.should_not be_available
       end
 
-      it "should not be available if destroyed" do 
-        product.destroy 
-        product.should_not be_available 
-      end 
+      it "should not be available if destroyed" do
+        product.destroy
+        product.should_not be_available
+      end
     end
 
     context "variants_and_option_values" do

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -33,7 +33,7 @@ describe "Visiting Products", inaccessible: true do
         visit spree.root_path
         within("#product_#{product.id}") do
           within(".price") do
-            page.should have_content("руб19.99")
+            expect(page).to have_content("19.99 ₽")
           end
         end
       end
@@ -41,7 +41,7 @@ describe "Visiting Products", inaccessible: true do
       it "on product page" do
         visit spree.product_path(product)
         within(".price") do
-          page.should have_content("руб19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
 
@@ -50,7 +50,7 @@ describe "Visiting Products", inaccessible: true do
         click_button "Add To Cart"
         click_link "Home"
         within(".cart-info") do
-          page.should have_content("РУБ19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
 
@@ -59,7 +59,7 @@ describe "Visiting Products", inaccessible: true do
         click_button "Add To Cart"
         click_button "Checkout"
         within("tr[data-hook=item_total]") do
-          page.should have_content("руб19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
     end
@@ -78,7 +78,6 @@ describe "Visiting Products", inaccessible: true do
     let!(:variant) { product.variants.create!(:price => 5.59) }
 
     before do
-      Spree::Config[:display_currency] = true
       # Need to have two images to trigger the error
       image = File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __FILE__))
       product.images.create!(:attachment => image)
@@ -106,15 +105,6 @@ describe "Visiting Products", inaccessible: true do
       click_link product.name
       within("#product-price") do
         expect(page).not_to have_content Spree.t(:out_of_stock)
-      end
-    end
-
-    # Regression test for #4342
-    it "does not fail when display_currency is true" do
-      Spree::Config[:display_currency] = true
-      click_link product.name
-      within("#cart-form") do
-        find('input[type=radio]')
       end
     end
   end

--- a/guides/content/developer/core/preferences.md
+++ b/guides/content/developer/core/preferences.md
@@ -1,0 +1,490 @@
+---
+title: "Preferences"
+section: core
+---
+
+## Overview
+
+Spree Preferences support general application configuration and preferences per model instance. Spree comes with preferences for your store like `logo` and`currency`. Additional preferences can be added by your application or included extensions.
+
+To implement preferences for a model, simply add a new column called `preferences`. This is an example migration for the `spree_products` table:
+
+```ruby
+class AddPreferencesColumnToSpreeProducts < ActiveRecord::Migration
+  def up
+    add_column :spree_products, :preferences, :text
+  end
+
+  def down
+    remove_column :spree_products, :preferences
+  end
+end
+```
+
+All instances will use the default value unless a value has been set for a specific record. For example, you could add a preference to `User` for e-mail notifications. Users would have the ability to modify this value without adding an extra column to your database table.
+
+Extensions may add to the Spree General Settings or create their own namespaced preferences.
+
+The first several sections of this guide describe preferences in a very general way. If you're just interested in making modifications to the existing preferences, you can skip ahead to the [Configuring Spree Preferences section](#configuring-spree-preferences). If you would like a more in-depth understanding of the underlying concepts used by the preference system, please read on.
+
+### Motivation
+
+Preferences for models within an application are very common. Although the rule of thumb is to keep the number of preferences available to a minimum, sometimes it's necessary if you want users to have optional preferences like disabling e-mail notifications.
+
+Both use cases are handled by Spree Preferences. They are easy to define, provide quick cached reads, persist across restarts and do not require additional columns to be added to your models' tables.
+
+## General Settings
+
+Spree comes with many application-wide preferences. They are defined in `core/app/models/spree/app_configuration.rb` and made available to your code through `Spree::Config`, e.g., `Spree::Config.site_name`.
+
+A limited set of the general settings are available in the admin interface of your store (`/admin/general_settings`).
+
+You can add additional preferences under the `spree/app_configuration` namespace or create your own subclass of `Preferences::Configuration`.
+
+```ruby
+# These will be saved with key: spree/app_configuration/hot_salsa
+Spree::AppConfiguration.class_eval do
+  preference :hot_salsa, :boolean
+  preference :dark_chocolate, :boolean, :default => true
+  preference :color, :string
+  preference :favorite_number
+  preference :language, :string, :default => 'English'
+end
+
+# Spree::Config is an instance of Spree::AppConfiguration
+Spree::Config.hot_salsa = false
+
+# Create your own class
+# These will be saved with key: kona/store_configuration/hot_coffee
+Kona::StoreConfiguration < Preferences::Configuration
+  preference :hot_coffee, :boolean
+  preference :color, :string, :default => 'black'
+end
+
+KONA::STORE_CONFIG = Kona::StoreConfiguration.new
+puts KONA::STORE_CONFIG.hot_coffee
+```
+
+## Defining Preferences
+
+You can define preferences for a model within the model itself:
+
+```ruby
+class User < ActiveRecord::Base
+  preference :hot_salsa, :boolean
+  preference :dark_chocolate, :boolean, :default => true
+  preference :color, :string
+  preference :favorite_number, :integer
+  preference :language, :string, :default => "English"
+end
+```
+
+In the above model, five preferences have been defined:
+
+* `hot_salsa`
+* `dark_chocolate`
+* `color`
+* `favorite_number`
+* `language`
+
+For each preference, a data type is provided. The types available are:
+
+* `boolean`
+* `string`
+* `password`
+* `integer`
+* `text`
+* `array`
+* `hash`
+
+An optional default value may be defined.
+
+## Accessing Preferences
+
+Once preferences have been defined for a model, they can be accessed either using the shortcut methods that are generated for each preference or the generic methods that are not specific to a particular preference.
+
+### Shortcut Methods
+
+There are several shortcut methods that are generated. They are shown below.
+
+Query methods:
+
+```ruby
+user.prefers_hot_salsa? # => false
+user.prefers_dark_chocolate? # => false
+```
+
+Reader methods:
+
+```ruby
+user.preferred_color      # => nil
+user.preferred_language   # => "English"
+```
+
+Writer methods:
+
+```ruby
+user.prefers_hot_salsa = false         # => false
+user.preferred_language = "English"    # => "English"
+```
+
+Check if a preference is available:
+
+```ruby
+user.has_preference? :hot_salsa
+```
+
+### Generic Methods
+
+Each shortcut method is essentially a wrapper for the various generic methods shown below:
+
+Query method:
+
+```ruby
+user.prefers?(:hot_salsa)       # => false
+user.prefers?(:dark_chocolate)  # => false
+```
+
+Reader methods:
+
+```ruby
+user.preferred(:color)      # => nil
+user.preferred(:language)   # => "English"
+```
+
+```ruby
+user.get_preference :color
+user.get_preference :language
+```
+
+Writer method:
+
+```ruby
+user.set_preference(:hot_salsa, false)     # => false
+user.set_preference(:language, "English")  # => "English"
+```
+
+### Accessing All Preferences
+
+You can get a hash of all stored preferences by accessing the `preferences` helper:
+
+```ruby
+user.preferences # => {"language"=>"English", "color"=>nil}
+```
+
+This hash will contain the value for every preference that has been defined for the model instance, whether the value is the default or one that has been previously stored.
+
+### Default and Type
+
+You can access the default value for a preference:
+
+```ruby
+user.preferred_color_default # => 'blue'
+```
+
+Types are used to generate forms or display the preference. You can also get the type defined for a preference:
+
+```ruby
+user.preferred_color_type # => :string
+```
+
+## Configuring Spree Preferences
+
+Up until now we've been discussing the general preference system that was adapted to Spree. This has given you a general idea of what types of preference features are theoretically supported. Now, let's start to look specifically at how Spree is using these preferences for configuration.
+
+### Reading the Current Preferences
+
+At the heart of Spree preferences lies the `Spree::Config` constant. This object provides general access to the configuration settings anywhere in the application.
+
+These settings can be accessed from initializers, models, controllers, views, etc.
+
+The `Spree::Config` constant returns an instance of `Spree::AppConfiguration` which is where the default values for all of the general Spree preferences are defined.
+
+You can access these preferences directly in code. To see this in action, just fire up `rails console` and try the following:
+
+```ruby
+>> Spree::Config.admin_interface_logo
+=> "logo/spree_50.png"
+>> Spree::Config.admin_products_per_page
+=> 10
+```
+
+The above examples show the default configuration values for these preferences. The defaults themselves are coded within the `Spree::AppConfiguration` class.
+
+```ruby
+class Spree::AppConfiguration < Configuration
+  #... snip ...
+  preference :allow_guest_checkout, :boolean, default: true
+  #... snip ...
+end
+```
+
+If you are using the default preferences without any modifications, then nothing will be stored in the database. If you set a value for the preference it will save it to `spree_preferences` or in our `preferences` column. It will use a memory cached version to maintain performance.
+
+### Overriding the Default Preferences
+
+The default Spree preferences in `Spree::AppConfiguration` can be changed using the `set` method of the `Spree::Config` module. For example to set the number of products shown on the products listing in the admin interface we could do the following:
+
+```ruby
+>> Spree::Config.admin_products_per_page = 20
+=> 20
+>> Spree::Config.admin_products_per_page
+=> 20
+```
+
+Here we are changing a preference to something other than the default as specified in `Spree::AppConfiguration`. In this case the preference system will persist the new value in the `spree_preferences` table.
+
+### Configuration Through the Spree Initializer
+
+During the Spree installation process, an initializer file is created within your application's source code. The initializer is found under `config/initializers/spree.rb`:
+
+```ruby
+Spree.config do |config|
+  # Example:
+  # Uncomment to override the default site name.
+  # config.site_name = "Spree Demo Site"
+end
+```
+
+The `Spree.config` block acts as a shortcut to setting `Spree::Config` multiple times. If you have multiple default preferences you would like to override within your code you may override them here. Using the initializer for setting the defaults is a nice shortcut, and helps keep your preferences organized in a standard location.
+
+For example if you would like to change the logo location and if you want to tax using the shipping address you can accomplish this by doing the following:
+
+```ruby
+Spree.config do |config|
+  config.admin_interface_logo = 'logo/my_store.png'
+  config.tax_using_ship_address = true
+end
+```
+
+***
+Initializing preferences in `config/initializer.rb` will overwrite any changes that were made through the admin user interface when you restart.
+***
+
+### Configuration Through the Admin Interface
+
+The Spree admin interface has several different screens where various settings can be configured. For instance, the `admin/general_settings` URL in your Spree application can be used to configure the values for the site name and the site URL. This is basically equivalent to calling `Spree::Config.set(currency: "CDN", currency_thousands_separator: " ")` directly in your Ruby code.
+
+## Site-Wide Preferences
+
+You can define preferences that are site-wide and don't apply to a specific instance of a model by creating a configuration file that inherits from `Spree::Preferences::Configuration`.
+
+```ruby
+class Spree::MyApplicationConfiguration < Spree::Preferences::Configuration
+  preference :theme, :string, :default => "Default"
+  preference :show_splash_page, :boolean
+  preference :number_of_articles, :integer
+end
+```
+
+In the above configuration file, three preferences have been defined:
+
+* theme
+* show_splash_page
+* number_of_articles
+
+It is recommended to create the configuration file in the `lib/` directory.
+
+***
+Extensions can also define site-wide preferences. For more information on using preferences like this with extensions, check out the [Extensions Tutorial](extensions_tutorial).
+***
+
+### Configuring Site-Wide Preferences
+
+The recommended way to configure site-wide preferences is through an initializer. Let's take a look at configuring the preferences defined in the previous configuration example.
+
+```ruby
+module Spree
+  MyApp::Config = Spree::MyApplicationConfiguration.new
+end
+
+MyApp::Config[:theme] = "blue_theme"
+MyApp::Config[:show_spash_page] = true
+MyApp::Config[:number_of_articles] = 5
+```
+
+The `MyApp` name used here is an example and should be replaced with your actual application's name, found in `config/application.rb`.
+
+The above example will configure the preferences we defined earlier. Take note of the second line. In order to set and get preferences using `MyApp::Config`, we must first instantiate the configuration object.
+
+## Spree Configuration Options
+
+This section lists all of the configuration options for the current version of Spree.
+
+`address_requires_state`
+
+Will determine if the state field should appear on the checkout page. Defaults to `true`.
+
+`admin_interface_logo`
+
+The path to the logo to display on the admin interface. Can be different from `Spree::Config[:logo]`. Defaults to `logo/spree_50.png`.
+
+`admin_products_per_page`
+
+How many products to display on the products listing in the admin interface. Defaults to 10.
+
+`allow_backorder_shipping`
+
+Determines if an `InventoryUnit` can ship or not. Defaults to `false`.
+
+`allow_checkout_on_gateway_error`
+
+Continues the checkout process even if the payment gateway error failed. Defaults to `false`.
+
+`alternative_shipping_phone`
+
+Determines if an alternative phone number should be present for the shipping address on the checkout page. Defaults to `false`.
+
+`always_put_site_name_in_title`
+
+Determines if the site name (`current_store.site_name`) should be placed into the title. Defaults to `true`.
+
+`attachment_default_url`
+
+Tells `Paperclip` the form of the URL to use for attachments which are missing.
+
+`attachment_path`
+
+Tells `Paperclip` the path at which to store images.
+
+`attachment_styles`
+
+A JSON hash of different styles that are supported by attachments. Defaults to:
+
+```json
+{
+  "mini":"48x48>",
+  "small":"100x100>",
+  "product":"240x240>",
+  "large":"600x600>"
+}
+```
+
+`attachment_default_style`
+
+A key from the list of styles from `Spree::Config[:attachment_styles]` that is the default style for images. Defaults to the the `product` style.
+
+`auto_capture`
+
+Depending on whether or not Spree is configured to "auto capture" the credit card, either a purchase or an authorize operation will be performed on the card (via the current credit card gateway).  Defaults to `false`.
+
+`checkout_zone`
+
+Limits the checkout to countries from a specific zone, by name. Defaults to `nil`.
+
+`company`
+
+Determines whether or not a field for "Company" displays on the checkout pages for shipping and billing addresses. Defaults to `false`.
+
+`currency`
+
+The three-letter currency code for the currency that prices will be displayed in. Defaults to "USD".
+
+`default_country_id`
+
+The default country's id. Defaults to 214, as this is the id for the United States within the seed data.
+
+`dismissed_spree_alerts`
+
+The list of alert IDs that you have dismissed.
+
+`last_check_for_spree_alerts`
+
+Stores the last time that alerts were checked for. Alerts are checked for every 12 hours.
+
+`layout`
+
+The path to the layout of your application, relative to the `app/views` directory. Defaults to `spree/layouts/spree_application`. To make Spree use your application's layout rather than Spree's default, use this:
+
+```ruby
+Spree.config do |config|
+  config.layout = "application"
+end
+```
+
+`logo`
+
+The logo to display on your frontend. Defaults to `logo/spree_50.png`.
+
+`max_level_in_taxons_menu`
+
+The number of levels to descend when viewing a taxon menu. Defaults to `1`.
+
+`orders_per_page`
+
+The number of orders to display on the orders listing in the admin backend. Defaults to `15`.
+
+`prices_inc_tax`
+
+Determines if prices are labelled as including tax or not. Defaults to `false`.
+
+`shipment_inc_vat`
+
+Determines if shipments should include VAT calculations. Defaults to `false`.
+
+`shipping_instructions`
+
+Determines if shipping instructions are requested or not when checking out. Defaults to `false`.
+
+`show_descendents`
+
+Determines if taxon descendants are shown when showing taxons. Defaults to `true`.
+
+`show_only_complete_orders_by_default`
+
+Determines if, on the admin listing screen, only completed orders should be shown. Defaults to `true`.
+
+`show_variant_full_price`
+
+Determines if the variant's full price or price difference from a product should be displayed on the product's show page. Defaults to `false`.
+
+`tax_using_ship_address`
+
+Determines if tax information should be based on shipping address, rather than the billing address. Defaults to `true`.
+
+`track_inventory_levels`
+
+Determines if inventory levels should be tracked when products are purchased at checkout. This option causes new `InventoryUnit` objects to be created when a product is bought. Defaults to `true`.
+
+## S3 Support
+
+To configure Spree to upload images to S3, put these lines into `config/initializers/spree.rb`:
+
+```ruby
+Spree.config do |config|
+  config.use_s3 = true
+  config.s3_bucket = '<bucket>'
+  config.s3_access_key = "<key>"
+  config.s3_secret = "<secret>"
+end
+```
+
+It's also a good idea to not include the `rails_root` path inside the `attachment_path` configuration option, which by default is this:
+
+```ruby
+:rails_root/public/spree/products/:id/:style/:basename.:extension
+```
+
+To change this, add the following line underneath the `s3_secret` configuration setting:
+
+```ruby
+config.attachment_path = '/spree/products/:id/:style/:basename.:extension'
+```
+
+If you're using the Western Europe S3 server, you will need to set two additional options inside this block:
+
+```ruby
+Spree.config do |config|
+  ...
+  config.attachment_url = ":s3_eu_url"
+  config.s3_host_alias = "s3-eu-west-1.amazonaws.com"
+end
+```
+
+Additionally, you will need to tell `paperclip` how to construct the URLs for your images by placing this code outside the `config` block inside `config/initializers/spree.rb`:
+
+```ruby
+Paperclip.interpolates(:s3_eu_url) do |attachment, style|
+  "#{attachment.s3_protocol}://#{Spree::Config[:s3_host_alias]}/#{attachment.bucket_name}/#{attachment.path(style).gsub(%r{^/}, "")}"
+end
+```

--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -12,7 +12,7 @@ end
 # reference it as such. Make it explicit here that this table has been renamed.
 Spree::CreditCard.table_name = 'spree_credit_cards'
 
-creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2014, :last_digits => '1111',
+creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2020, :last_digits => '1111',
                                       :name => 'Sean Schofield', :gateway_customer_profile_id => 'BGS-1234')
 
 Spree::Order.all.each_with_index do |order, index|


### PR DESCRIPTION
Remove Spree::Money preferences

This hurt performance since each instantiation of a Spree::Money object
required 6 preference (and thus cache) lookups.

RubyMoney does most of this better by default:
- The decimal mark and thousands separator are taken from i18n, allowing
  multilingual sites to now format their moneys correctly.
- symbol_first is configured by RubyMoney per-currency, this allows
  multi-currency sites to now correctly format their currencies. This is
  also better for new single currency sites, as there is no longer a
  need to configure this.

sign_before_symbol was the one exception, where our default was
different (I would argue better) than the RubyMoney team's. So I have
added Spree::Money.default_formatting_rules, which is analogous to
Money..default_formatting_rules which has a default of
{sign_before_symbol: true}.

This Spree::Money.default_formatting_rules can also be used in place of
the existing preference values.

Fixes #5966
