### PR TITLE
Updated Rails Dependency

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize'
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.0'
-  s.add_dependency 'rails', '~> 4.1.4'
+  s.add_dependency 'rails', '~> 4.2.7'
   s.add_dependency 'ransack', '~> 1.2.2'
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
4.1 is now unsupported and we need those sweet security fixes
