### PR TITLE
Update deface to a version compatible with nokogiri 1.7

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '= 0.7.6'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
   s.add_dependency 'cancancan', '~> 1.8.4'
-  s.add_dependency 'deface', '~> 1.0.0'
+  s.add_dependency 'deface', '~> 1.2.0'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0.4'


### PR DESCRIPTION
Currently our fm-ecom bundle is invalid, making it difficult to add gems. The issue is that deface, a dependency of Spree, pins nokogiri to v1.6.x, which has security vulnerabilities.

We need to update deface to v1.2.0 to allow us to use nokogiri 1.7.x without breaking our bundle.